### PR TITLE
Enable Staticman comment moderation

### DIFF
--- a/staticman.yml
+++ b/staticman.yml
@@ -51,7 +51,7 @@ comments:
   # Whether entries need to be approved before they are published to the main
   # branch. If set to `true`, a pull request will be created for your approval.
   # Otherwise, entries will be published to the main branch automatically.
-  moderation: false
+  moderation: true
 
   # Akismet spam detection.
   # akismet:


### PR DESCRIPTION
You may refer to recent spam comments for the rationale.  This PR switches on the comment moderation, so that visitors' comments would only be published upon site owner's approval.

P.S. I intended this feature to be enabled by default, by the blog theme owner switched it off at https://github.com/daattali/beautiful-jekyll/commit/4178dd746499ea1bd013190bf1a67aeda9f0e22b because he upholds a convention of turning everything off in his project.  Anyways, he owns the project.