### PR TITLE
Add reCAPTCHA to the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -136,8 +136,8 @@ staticman:
   reCaptcha:
     # reCaptcha for Staticman (OPTIONAL)
     # If you use reCaptcha, you must also set these parameters in staticman.yml
-    siteKey  : # Use your own site key, you need to apply for one on Google
-    secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
+    siteKey  : 6Lc7gaoUAAAAAA1n1d-U6MatFxkhvTTYYNzZshLZ # Use your own site key, you need to apply for one on Google
+    secret   : BuPdmIGltlN0jn//ZSG4idqtfU4qMf6UETQPS8wUCzOQR6+qN1O4dGzVC5wHmIKhFZLbqu30o1NK0tveqbAKtxKO0yMYbR8nqEmAzpiLUB4DxAtlvL9SP9RRG9xSwKaW5iRKJ83zK9sZXtqzEbXKls+Xi/iLVypZ8zbzr9OLbWvATMJ9ZrcJ/J5145R/TUsKsWbJqnQWGpCF6qVq6dvjdh9wUh2fdWsVCRTb2PGbgXMT5Bl7Q37U9uEJCYPzzorqbz7jq5wjPkiSVmxMLk8JmDPkcyfLoKCqSzmNDWMbZWkeWI5RKz0ow6tIIbuu+WuMz2wXxkTX6HnE8KlJcA6WaQ== # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
 
 # --- Misc --- #
 


### PR DESCRIPTION
In https://github.com/einsteinpy/einsteinpy.github.io/pull/25#issuecomment-505002646, I've bolded the **s** in "config file**s**" because since Staticman v2, the setup for a static blog requires two config files.  You may refer to https://github.com/daattali/beautiful-jekyll/pull/440#issuecomment-449610703 for reference.  Commit 3785222 only adds reCAPTCHA to `staticman.yml`, so it doesn't show up on the site.